### PR TITLE
Don't use f strings & set Python 3 requires in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 ###############################################################################
 
 plugin_identifier = "wifistatus"
-plugin_package = f"octoprint_{plugin_identifier}"
+plugin_package = "octoprint_{}".format(plugin_identifier)
 plugin_name = "OctoPrint_WiFiStatus"
 plugin_version = "1.5.1"
 plugin_description = "Displays WiFi status on the navbar"
@@ -18,7 +18,7 @@ plugin_requires = ["netifaces>=0.10.9,<1"]
 plugin_additional_data = []
 plugin_additional_packages = []
 plugin_ignored_packages = []
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">3.7,<4"}
 
 ###############################################################################
 


### PR DESCRIPTION
Should hopefully avoid some issues with users installing this on Python 2. People *do not read* sometimes do they?

Using f strings results in a syntax error, rather than the more sensible `OctoPrint-WiFiStatus requires a different Python version. 2.7 not in '>3.7, <4'` or something like that.

OctoPrint doesn't show them the plugin if it is incompatible - so they open the page, scroll past the warning and compatibility information and then attempt to install it manually.

I didn't know you didn't have this in the file - we've been recommending it for new plugins developed with Python 3 only, since it provides a more sensible error message and some users can figure it out and even advise other users as well.

Triggered by https://github.com/OctoPrint/plugins.octoprint.org/issues/827...